### PR TITLE
Remove the ORG and SPACE env variables for `kubectl`

### DIFF
--- a/deployment/tests/kubernetes.sh
+++ b/deployment/tests/kubernetes.sh
@@ -6,9 +6,7 @@ set -e
 # variables
 bluemix login \
   --apikey "${BLUEMIX_API_KEY}" \
-  -a "${BLUEMIX_API_ENDPOINT}" \
-  -o "${BLUEMIX_ORGANIZATION}" \
-  -s "${BLUEMIX_SPACE}"
+  -a "${BLUEMIX_API_ENDPOINT}"
 
 bluemix cs init \
   --host "${BLUEMIX_CONTAINER_SERVICE_HOST}"


### PR DESCRIPTION
Supersedes #4 now that we are using a different Kubernetes Cluster on Bluemix (see #5), that actually allows our tests to run.