### PR TITLE
Force bluemix command to not try and prompt for upgrade

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -19,4 +19,5 @@ RUN \
 
 RUN \
   bluemix plugin install container-registry -r Bluemix && \
-  bluemix plugin install container-service -r Bluemix
+  bluemix plugin install container-service -r Bluemix && \
+  bluemix config --check-version false


### PR DESCRIPTION
This ensures that when a new version is available upstream, it doesn't prompt on STDIN for a `y|n` response to upgrade. When this happens it just blocks the build until our inactivity timeout throws the build away.